### PR TITLE
Fix "E: Invalid operation build-dep" on Jessie

### DIFF
--- a/i3-gaps-deb
+++ b/i3-gaps-deb
@@ -184,7 +184,7 @@ igd_handleJessieBackportsSpecialCase()
 igd_installBuildDeps()
 {
 	igd_readAndContinue "Installing (basic) build dependencies..."
-	sudo apt -y build-dep i3-wm
+	sudo apt-get -y build-dep i3-wm
 	igd_readAndContinue "Installing (additional) build dependencies..."
 	sudo apt -y install \
 		devscripts dpkg-dev \


### PR DESCRIPTION
Hey :)

Really cool project :100: 

I just fixed an error on Debian Jessie which says that build-dep is not valid.

lsb_release output:
```
Distributor ID:	Debian
Description:	Debian GNU/Linux 8.7 (jessie)
Release:	8.7
Codename:	jessie
```

