### PR TITLE
fix: [regex] Fixed multi-match version number in current version.

### DIFF
--- a/i3-gaps-deb
+++ b/i3-gaps-deb
@@ -260,7 +260,7 @@ igd_updateDebianChangelog()
 	igd_log "Updating Debian changelog..."
 
 	local versionFoo="$(head -1 debian/changelog | cut -d'(' -f2 | cut -d'-' -f1 || echo "0.0.0")"
-	local versionBar="$(grep -o "\w*[0-9\.]\w*" I3_VERSION || echo "0.0.0")"
+	local versionBar="$(grep -P -o "\d+(?:\.\d+)+" I3_VERSION || echo "0.0.0")"
 
 	local version="${versionFoo}"
 	if dpkg --compare-versions "${versionFoo}" lt "${versionBar}"; then version="${versionBar}"; fi


### PR DESCRIPTION
Contents of I3_VERSION:
```
4.16.1-non-git
```

Old buggy:
```bash
$ grep -o "\w*[0-9\.]\w*" I3_VERSION || echo "0.0.0"
4.16
.1
```

```bash
$ grep -P -o "\d+(?:\.\d+)+" I3_VERSION || echo "0.0.0"
4.16.1
```