### PR TITLE
Add missing build dependency.

### DIFF
--- a/i3-gaps-deb
+++ b/i3-gaps-deb
@@ -206,7 +206,8 @@ igd_installBuildDeps()
 		libxcb-xrm-dev \
 		libxcb-xkb-dev \
 		libxkbcommon-dev \
-		libxkbcommon-x11-dev
+		libxkbcommon-x11-dev \
+        libxcb-shape0-dev
 }
 
 igd_ensureGitToBeInstalled()


### PR DESCRIPTION
Add missing build dependency on `libxcb-shape0-dev`.

Signed-off-by: Joseph Benden <joe@benden.us>