### PR TITLE
Disable sanitizers

### DIFF
--- a/0001-debian-Disable-sanitizers.patch
+++ b/0001-debian-Disable-sanitizers.patch
@@ -1,0 +1,25 @@
+From f6ecd304149aad96c0a2fe417e392a395043cfb5 Mon Sep 17 00:00:00 2001
+From: Joseph Benden <joe@benden.us>
+Date: Fri, 22 Mar 2019 09:08:07 -0700
+Subject: [PATCH] debian: Disable sanitizers.
+
+---
+ debian/rules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debian/rules b/debian/rules
+index d5c3068..11918d5 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -15,7 +15,7 @@ override_dh_auto_test:
+ 
+ override_dh_auto_configure:
+ 	# The default is /usr/share/doc/i3
+-	dh_auto_configure -- --docdir=/usr/share/doc/i3-wm
++	dh_auto_configure -- --docdir=/usr/share/doc/i3-wm --disable-sanitizers
+ 
+ override_dh_builddeb:
+ 	# bintray does not support xz currently.
+-- 
+2.7.4
+

--- a/i3-gaps-deb
+++ b/i3-gaps-deb
@@ -275,6 +275,9 @@ igd_updateDebianChangelog()
 
 igd_fixRules()
 {
+	igd_log "Disable sanitizers..."
+	patch --forward -r - -p1 <${igd_BASEDIR}/0001-debian-Disable-sanitizers.patch || igd_log "Already patched."
+
 	igd_log "Fix rules file..."
 	cat <<EOF >>debian/rules
 

--- a/i3-gaps-deb
+++ b/i3-gaps-deb
@@ -206,7 +206,8 @@ igd_installBuildDeps()
 		libxcb-xrm-dev \
 		libxcb-xkb-dev \
 		libxkbcommon-dev \
-		libxkbcommon-x11-dev
+		libxkbcommon-x11-dev \
+        libxcb-shape0-dev
 }
 
 igd_ensureGitToBeInstalled()


### PR DESCRIPTION
This patch permits building i3 without any sanitizers enabled.

This is /highly/ desirable, as all sanitizers are meant for development builds, only.

A nice side-effect from disabling these sanitizers, is the i3 process no longer shows TBs of used virtual memory. This in turn allows my custom set `/proc/sys/vm/overcommit_memory` tuning to function.