### PR TITLE
Added option to install i3 via apt if not present in system instead of aborting

### DIFF
--- a/i3-gaps-deb
+++ b/i3-gaps-deb
@@ -134,8 +134,11 @@ igd_ensureI3ToBeInstalled()
 	igd_log "Checking i3 installation..."
 
 	if ! dpkg -s i3 &> /dev/null; then
-		igd_readAndContinue "This tool assumes that you have \"i3\" already installed. Please do so..."
-		exit 42
+		if igd_question "i3 not found, install it using apt?" "y"; then
+			sudo apt-get -y install i3
+		else
+			exit 42
+		fi
 	fi
 }
 


### PR DESCRIPTION
Replaced igd_readAndContinue with igd_question to ask if the user prefers to install i3 via apt if not found in system. If agreed, install it or else, throw the same error as before (exit 42)